### PR TITLE
Add web app and improve task tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # Task Tracker
 
-This repository contains a simple command line task tracker that stores tasks in a local SQLite database. Tasks can be added with a priority, listed in priority order and marked as done.
+This repository contains a simple task tracker backed by SQLite. Tasks can be managed either from the command line or through a lightweight web interface. Each task has a priority and an optional due date and can be marked as done when completed.
 
 ## Usage
 
 ```
-python3 task_tracker.py add "Buy milk" -p 2
+python3 task_tracker.py add "Buy milk" -p 2 -d 2024-12-31
 python3 task_tracker.py list
 python3 task_tracker.py done 1
+```
+
+To run the web app:
+
+```
+python3 web_app.py
 ```
 
 Run `python3 task_tracker.py --help` for all available options.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+flask

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -1,6 +1,6 @@
 import sqlite3
 import argparse
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 DB_FILE = "tasks.db"
 
@@ -11,33 +11,43 @@ class TaskTracker:
         self._init_db()
 
     def _init_db(self) -> None:
+        """Initialise the tasks table and upgrade old schemas."""
         self.conn.execute(
             """
             CREATE TABLE IF NOT EXISTS tasks (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 description TEXT NOT NULL,
                 priority INTEGER NOT NULL DEFAULT 1,
+                due_date TEXT,
                 done INTEGER NOT NULL DEFAULT 0
             )
             """
         )
+        # If the table existed previously without the due_date column we need
+        # to add it. Older SQLite versions ignore "ADD COLUMN" if it already
+        # exists which keeps the operation idempotent.
+        columns = [row[1] for row in self.conn.execute("PRAGMA table_info(tasks)")]
+        if "due_date" not in columns:
+            self.conn.execute("ALTER TABLE tasks ADD COLUMN due_date TEXT")
         self.conn.commit()
 
-    def add_task(self, description: str, priority: int = 1) -> None:
+    def add_task(self, description: str, priority: int = 1, due_date: Optional[str] = None) -> None:
+        """Add a new task."""
         self.conn.execute(
-            "INSERT INTO tasks(description, priority, done) VALUES (?, ?, 0)",
-            (description, priority),
+            "INSERT INTO tasks(description, priority, due_date, done) VALUES (?, ?, ?, 0)",
+            (description, priority, due_date),
         )
         self.conn.commit()
 
-    def list_tasks(self, show_all: bool = False) -> List[Tuple[int, str, int, int]]:
+    def list_tasks(self, show_all: bool = False) -> List[Tuple[int, str, int, Optional[str], int]]:
+        """Return tasks sorted by priority and due date."""
         if show_all:
             cursor = self.conn.execute(
-                "SELECT id, description, priority, done FROM tasks ORDER BY done, priority DESC"
+                "SELECT id, description, priority, due_date, done FROM tasks ORDER BY done, priority DESC, COALESCE(due_date, '')"
             )
         else:
             cursor = self.conn.execute(
-                "SELECT id, description, priority, done FROM tasks WHERE done=0 ORDER BY priority DESC"
+                "SELECT id, description, priority, due_date, done FROM tasks WHERE done=0 ORDER BY priority DESC, COALESCE(due_date, '')"
             )
         return cursor.fetchall()
 
@@ -55,6 +65,9 @@ def main() -> None:
     add_parser.add_argument(
         "-p", "--priority", type=int, default=1, help="Priority (higher means more important)"
     )
+    add_parser.add_argument(
+        "-d", "--due-date", help="Optional due date as YYYY-MM-DD"
+    )
 
     list_parser = subparsers.add_parser("list", help="List tasks")
     list_parser.add_argument(
@@ -68,12 +81,13 @@ def main() -> None:
     tracker = TaskTracker()
 
     if args.command == "add":
-        tracker.add_task(args.description, args.priority)
+        tracker.add_task(args.description, args.priority, args.due_date)
     elif args.command == "list":
         tasks = tracker.list_tasks(args.all)
-        for tid, desc, priority, done in tasks:
+        for tid, desc, priority, due, done in tasks:
             status = "done" if done else "pending"
-            print(f"[{tid}] (p={priority}) {desc} - {status}")
+            due_info = f" due {due}" if due else ""
+            print(f"[{tid}] (p={priority}) {desc}{due_info} - {status}")
     elif args.command == "done":
         tracker.mark_done(args.task_id)
 

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -6,18 +6,20 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from task_tracker import TaskTracker
+from web_app import app
 
 
 def test_add_list_done(tmp_path):
     db_path = tmp_path / "tasks.db"
     tracker = TaskTracker(str(db_path))
 
-    tracker.add_task("task one", priority=2)
+    tracker.add_task("task one", priority=2, due_date="2024-01-01")
     tracker.add_task("task two", priority=1)
 
     tasks = tracker.list_tasks()
     assert len(tasks) == 2
     assert tasks[0][1] == "task one"  # highest priority first
+    assert tasks[0][3] == "2024-01-01"
 
     tracker.mark_done(tasks[0][0])
 
@@ -27,4 +29,19 @@ def test_add_list_done(tmp_path):
 
     all_tasks = tracker.list_tasks(show_all=True)
     assert len(all_tasks) == 2
+
+
+def test_web_app(tmp_path):
+    db_path = tmp_path / "tasks.db"
+    tracker = TaskTracker(str(db_path))
+    app.config.update({'TESTING': True})
+
+    with app.test_client() as client:
+        # override tracker in web_app with our test tracker
+        import web_app
+        web_app.tracker = tracker
+
+        client.post('/add', data={'description': 'web task', 'priority': '3'})
+        resp = client.get('/')
+        assert b'web task' in resp.data
 

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,50 @@
+from flask import Flask, request, redirect, url_for, render_template_string
+from task_tracker import TaskTracker
+
+app = Flask(__name__)
+tracker = TaskTracker()
+
+TEMPLATE = """
+<!doctype html>
+<title>Task Tracker</title>
+<h1>Tasks</h1>
+<form method="post" action="/add">
+    <input type="text" name="description" placeholder="Task description" required>
+    <input type="number" name="priority" value="1" min="1">
+    <input type="date" name="due_date">
+    <button type="submit">Add Task</button>
+</form>
+<ul>
+{% for tid, desc, priority, due, done in tasks %}
+<li>
+    [{{tid}}] {{desc}} (p={{priority}}){% if due %} due {{due}}{% endif %} - {{'done' if done else 'pending'}}
+    {% if not done %}
+    <form method="post" action="/done/{{tid}}" style="display:inline;">
+        <button type="submit">Done</button>
+    </form>
+    {% endif %}
+</li>
+{% endfor %}
+</ul>
+"""
+
+@app.route("/")
+def index():
+    tasks = tracker.list_tasks(show_all=True)
+    return render_template_string(TEMPLATE, tasks=tasks)
+
+@app.route("/add", methods=["POST"])
+def add():
+    description = request.form["description"]
+    priority = int(request.form.get("priority", 1))
+    due_date = request.form.get("due_date") or None
+    tracker.add_task(description, priority, due_date)
+    return redirect(url_for("index"))
+
+@app.route("/done/<int:task_id>", methods=["POST"])
+def done(task_id: int):
+    tracker.mark_done(task_id)
+    return redirect(url_for("index"))
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary
- add optional due dates and persist them in sqlite
- expose command line option for due dates
- build minimal Flask web interface
- update documentation and tests

## Testing
- `python3 -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68439b66aa108323a402fe7f2592efdd