### PR TITLE
Improve tracker and add Replit deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,20 @@ This repository contains a simple task tracker backed by SQLite. Tasks can be ma
 python3 task_tracker.py add "Buy milk" -p 2 -d 2024-12-31
 python3 task_tracker.py list
 python3 task_tracker.py done 1
+python3 task_tracker.py delete 2
 ```
 
 To run the web app:
 
 ```
 python3 web_app.py
+```
+
+On [Replit](https://replit.com) the application can be started by running
+`main.py` which launches the web interface using the port provided by Replit:
+
+```
+python3 main.py
 ```
 
 Run `python3 task_tracker.py --help` for all available options.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+from web_app import app
+import os
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", 3000))
+    app.run(host="0.0.0.0", port=port)

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -56,6 +56,11 @@ class TaskTracker:
         self.conn.execute("UPDATE tasks SET done=1 WHERE id=?", (task_id,))
         self.conn.commit()
 
+    def delete_task(self, task_id: int) -> None:
+        """Delete a task permanently."""
+        self.conn.execute("DELETE FROM tasks WHERE id=?", (task_id,))
+        self.conn.commit()
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Simple task tracker")
@@ -78,6 +83,9 @@ def main() -> None:
     done_parser = subparsers.add_parser("done", help="Mark task as done")
     done_parser.add_argument("task_id", type=int, help="ID of the task to mark as done")
 
+    delete_parser = subparsers.add_parser("delete", help="Delete a task")
+    delete_parser.add_argument("task_id", type=int, help="ID of the task to delete")
+
     args = parser.parse_args()
     tracker = TaskTracker()
 
@@ -91,6 +99,8 @@ def main() -> None:
             print(f"[{tid}] (p={priority}) {desc}{due_info} - {status}")
     elif args.command == "done":
         tracker.mark_done(args.task_id)
+    elif args.command == "delete":
+        tracker.delete_task(args.task_id)
 
 
 if __name__ == "__main__":

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -27,8 +27,11 @@ def test_add_list_done(tmp_path):
     assert len(remaining) == 1
     assert remaining[0][1] == "task two"
 
+    tracker.delete_task(remaining[0][0])
+    assert tracker.list_tasks() == []
+
     all_tasks = tracker.list_tasks(show_all=True)
-    assert len(all_tasks) == 2
+    assert len(all_tasks) == 1
 
 
 def test_web_app(tmp_path):
@@ -44,4 +47,10 @@ def test_web_app(tmp_path):
         client.post('/add', data={'description': 'web task', 'priority': '3'})
         resp = client.get('/')
         assert b'web task' in resp.data
+
+        # mark done and delete via HTTP
+        task_id = tracker.list_tasks()[0][0]
+        client.post(f'/done/{task_id}')
+        client.post(f'/delete/{task_id}')
+        assert tracker.list_tasks() == []
 

--- a/web_app.py
+++ b/web_app.py
@@ -23,6 +23,9 @@ TEMPLATE = """
         <button type="submit">Done</button>
     </form>
     {% endif %}
+    <form method="post" action="/delete/{{tid}}" style="display:inline;">
+        <button type="submit">Delete</button>
+    </form>
 </li>
 {% endfor %}
 </ul>
@@ -46,5 +49,12 @@ def done(task_id: int):
     tracker.mark_done(task_id)
     return redirect(url_for("index"))
 
+@app.route("/delete/<int:task_id>", methods=["POST"])
+def delete(task_id: int):
+    tracker.delete_task(task_id)
+    return redirect(url_for("index"))
+
 if __name__ == "__main__":
-    app.run()
+    import os
+    port = int(os.getenv("PORT", 5000))
+    app.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- enable deleting tasks through CLI and web
- add HTTP route for deleting tasks
- run the web app on the port given by the environment
- provide Replit entrypoint via `main.py`
- document new command and Replit usage
- test deletion functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a02516148323a07e97fb1bc2477c