### PR TITLE
Enable priority sorting and seed demo tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ This repository contains a simple task tracker backed by SQLite. Tasks can be ma
 ```
 python3 task_tracker.py add "Buy milk" -p 2 -d 2024-12-31
 python3 task_tracker.py list
+python3 task_tracker.py list --asc
 python3 task_tracker.py done 1
 python3 task_tracker.py delete 2
+python3 task_tracker.py seed  # add sample tasks
 ```
 
 To run the web app:

--- a/web_app.py
+++ b/web_app.py
@@ -2,12 +2,18 @@ from flask import Flask, request, redirect, url_for, render_template_string
 from task_tracker import TaskTracker
 
 app = Flask(__name__)
-tracker = TaskTracker()
+tracker = TaskTracker(populate_dummy=True)
 
 TEMPLATE = """
 <!doctype html>
 <title>Task Tracker</title>
 <h1>Tasks</h1>
+<form method="get" action="/">
+    <select name="sort" onchange="this.form.submit()">
+        <option value="desc" {% if sort != 'asc' %}selected{% endif %}>Priority high->low</option>
+        <option value="asc" {% if sort == 'asc' %}selected{% endif %}>Priority low->high</option>
+    </select>
+</form>
 <form method="post" action="/add">
     <input type="text" name="description" placeholder="Task description" required>
     <input type="number" name="priority" value="1" min="1">
@@ -33,8 +39,9 @@ TEMPLATE = """
 
 @app.route("/")
 def index():
-    tasks = tracker.list_tasks(show_all=True)
-    return render_template_string(TEMPLATE, tasks=tasks)
+    sort = request.args.get("sort", "desc")
+    tasks = tracker.list_tasks(show_all=True, ascending=(sort == "asc"))
+    return render_template_string(TEMPLATE, tasks=tasks, sort=sort)
 
 @app.route("/add", methods=["POST"])
 def add():


### PR DESCRIPTION
## Summary
- allow sorting tasks ascending by priority
- add optional dummy data seeding
- update CLI to support `--asc` sorting and `seed` command
- web UI gets sort dropdown and seeded database
- document new commands in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a19f3ac48323b2ac7cdea3a08d2d