### PR TITLE
Add task editing and due-date sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ This repository contains a simple task tracker backed by SQLite. Tasks can be ma
 python3 task_tracker.py add "Buy milk" -p 2 -d 2024-12-31
 python3 task_tracker.py list
 python3 task_tracker.py list --asc
+python3 task_tracker.py list --sort-by due
 python3 task_tracker.py done 1
 python3 task_tracker.py delete 2
+python3 task_tracker.py edit 3 -d "Buy oat milk" --due-date 2024-11-30
 python3 task_tracker.py seed  # add sample tasks
 ```
 


### PR DESCRIPTION
## Summary
- allow tasks to be edited via CLI and web
- support sorting by due date in CLI and web UI
- document new commands in README
- test task editing and due-date sorting

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a65d075883239d9aa6b3d92fda9f