### PR TITLE
Add filtering, status options, and pagination

### DIFF
--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -73,7 +73,7 @@ def test_web_app(tmp_path):
         # add two tasks with due dates for sorting
         client.post('/add', data={'description': 't1', 'priority': '1', 'due_date': '2024-01-10'})
         client.post('/add', data={'description': 't2', 'priority': '1', 'due_date': '2024-01-05'})
-        resp = client.get('/?sort=due')
+        resp = client.get('/?sort=due_asc')
         body = resp.data.decode()
         assert body.index('t2') < body.index('t1')
 

--- a/web_app.py
+++ b/web_app.py
@@ -15,12 +15,23 @@ tr:nth-child(odd) { background-color: #ffffff; }
 </style>
 <h1>Tasks</h1>
 <form method="get" action="/">
+    <label for="q">Search:</label>
+    <input id="q" type="text" name="q" value="{{q}}">
+    <label for="status">Status:</label>
+    <select name="status" id="status" onchange="this.form.submit()">
+        <option value="" {% if not status_filter %}selected{% endif %}>All</option>
+        {% for st in statuses %}
+        <option value="{{st}}" {% if status_filter==st %}selected{% endif %}>{{st}}</option>
+        {% endfor %}
+    </select>
     <label for="sort">Sort:</label>
     <select name="sort" id="sort" onchange="this.form.submit()">
         <option value="desc" {% if sort == 'desc' %}selected{% endif %}>Priority high-&gt;low</option>
         <option value="asc" {% if sort == 'asc' %}selected{% endif %}>Priority low-&gt;high</option>
-        <option value="due" {% if sort == 'due' %}selected{% endif %}>Due date</option>
+        <option value="due_asc" {% if sort == 'due_asc' %}selected{% endif %}>Due earliest</option>
+        <option value="due_desc" {% if sort == 'due_desc' %}selected{% endif %}>Due latest</option>
     </select>
+    <button type="submit">Apply</button>
 </form>
 <form method="post" action="/add">
     <label for="description">Description:</label>
@@ -29,12 +40,17 @@ tr:nth-child(odd) { background-color: #ffffff; }
     <input id="priority" type="number" name="priority" value="1" min="1">
     <label for="due_date">Due date:</label>
     <input id="due_date" type="date" name="due_date">
+    <label for="status_new">Status:</label>
+    <select name="status" id="status_new">
+        {% for st in statuses %}
+        <option value="{{st}}" {% if st=='not started' %}selected{% endif %}>{{st}}</option>
+        {% endfor %}
+    </select>
     <button type="submit">Add Task</button>
 </form>
 <table>
 <thead>
     <tr>
-        <th>ID</th>
         <th>Description</th>
         <th>Priority</th>
         <th>Due date</th>
@@ -43,15 +59,14 @@ tr:nth-child(odd) { background-color: #ffffff; }
     </tr>
 </thead>
 <tbody>
-{% for tid, desc, priority, due, done in tasks %}
+{% for tid, desc, priority, due, done, status in tasks %}
     <tr>
-        <td>{{tid}}</td>
         <td>{{desc}}</td>
         <td>{{priority}}</td>
         <td>{{due if due else ''}}</td>
-        <td>{{'done' if done else 'pending'}}</td>
+        <td>{{status}}</td>
         <td>
-            {% if not done %}
+            {% if status != 'done' %}
             <form method="post" action="/done/{{tid}}" style="display:inline;">
                 <button type="submit">Done</button>
             </form>
@@ -67,23 +82,60 @@ tr:nth-child(odd) { background-color: #ffffff; }
 {% endfor %}
 </tbody>
 </table>
+<div>
+{% if page > 1 %}
+  <a href="{{ url_for('index', page=page-1, sort=sort, q=q, status=status_filter) }}">Previous</a>
+{% endif %}
+{% if has_next %}
+  <a href="{{ url_for('index', page=page+1, sort=sort, q=q, status=status_filter) }}">Next</a>
+{% endif %}
+</div>
 """
 
 @app.route("/")
 def index():
     sort = request.args.get("sort", "desc")
-    if sort == "due":
-        tasks = tracker.list_tasks(show_all=True, sort_by="due", ascending=True)
+    q = request.args.get("q", "")
+    status_filter = request.args.get("status") or None
+    page = int(request.args.get("page", 1))
+    limit = 10
+    offset = (page - 1) * limit
+    if sort == "due_asc":
+        sort_by, ascending = "due", True
+    elif sort == "due_desc":
+        sort_by, ascending = "due", False
     else:
-        tasks = tracker.list_tasks(show_all=True, ascending=(sort == "asc"))
-    return render_template_string(TEMPLATE, tasks=tasks, sort=sort)
+        sort_by, ascending = "priority", sort == "asc"
+    tasks = tracker.list_tasks(
+        show_all=True,
+        sort_by=sort_by,
+        ascending=ascending,
+        search=q or None,
+        status=status_filter,
+        limit=limit,
+        offset=offset,
+        with_status=True,
+    )
+    total = tracker.count_tasks(show_all=True, search=q or None, status=status_filter)
+    has_next = offset + limit < total
+    return render_template_string(
+        TEMPLATE,
+        tasks=tasks,
+        sort=sort,
+        q=q,
+        status_filter=status_filter,
+        page=page,
+        has_next=has_next,
+        statuses=["not started", "in progress", "done"],
+    )
 
 @app.route("/add", methods=["POST"])
 def add():
     description = request.form["description"]
     priority = int(request.form.get("priority", 1))
     due_date = request.form.get("due_date") or None
-    tracker.add_task(description, priority, due_date)
+    status = request.form.get("status", "not started")
+    tracker.add_task(description, priority, due_date, status)
     return redirect(url_for("index"))
 
 @app.route("/done/<int:task_id>", methods=["POST"])
@@ -102,15 +154,17 @@ def edit(task_id: int):
         description = request.form.get("description")
         priority = request.form.get("priority")
         due_date = request.form.get("due_date") or None
+        status = request.form.get("status")
         tracker.update_task(
             task_id,
             description=description,
             priority=int(priority) if priority else None,
             due_date=due_date,
+            status=status,
         )
         return redirect(url_for("index"))
     task = tracker.conn.execute(
-        "SELECT description, priority, due_date FROM tasks WHERE id=?",
+        "SELECT description, priority, due_date, status FROM tasks WHERE id=?",
         (task_id,),
     ).fetchone()
     edit_template = """
@@ -120,11 +174,18 @@ def edit(task_id: int):
         <label>Description:<input type=text name=description value=\"{{t[0]}}\"></label>
         <label>Priority:<input type=number name=priority value=\"{{t[1]}}\" min=1></label>
         <label>Due date:<input type=date name=due_date value=\"{{t[2] if t[2] else ''}}\"></label>
+        <label>Status:
+            <select name=status>
+            {% for st in statuses %}
+                <option value=\"{{st}}\" {% if t[3]==st %}selected{% endif %}>{{st}}</option>
+            {% endfor %}
+            </select>
+        </label>
         <button type=submit>Save</button>
     </form>
     <a href=\"/\">Back</a>
     """
-    return render_template_string(edit_template, t=task)
+    return render_template_string(edit_template, t=task, statuses=["not started", "in progress", "done"])
 
 if __name__ == "__main__":
     import os


### PR DESCRIPTION
## Summary
- add `status` column and pagination helpers in `task_tracker`
- extend CLI and APIs for status management
- enhance web app with search box, sorting, filtering, and pagination
- update tests for new sort option

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a8ee83288323a4dae5043118442e