### PR TITLE
Add comment and color metadata to tasks

### DIFF
--- a/web_app.py
+++ b/web_app.py
@@ -12,6 +12,7 @@ table { border-collapse: collapse; width: 100%; }
 th, td { padding: 8px; text-align: left; border-bottom: 1px solid #ddd; }
 tr:nth-child(even) { background-color: #f9f9f9; }
 tr:nth-child(odd) { background-color: #ffffff; }
+#commentBox { position: fixed; top: 20%; left: 20%; background: white; border: 1px solid #ccc; padding: 10px; display:none; }
 </style>
 <h1>Tasks</h1>
 <form method="get" action="/">
@@ -46,6 +47,10 @@ tr:nth-child(odd) { background-color: #ffffff; }
         <option value="{{st}}" {% if st=='not started' %}selected{% endif %}>{{st}}</option>
         {% endfor %}
     </select>
+    <label for="comment">Comment:</label>
+    <textarea id="comment" name="comment" rows="3" cols="30"></textarea>
+    <label for="color">Color:</label>
+    <input id="color" type="color" name="color" value="#ffffff">
     <button type="submit">Add Task</button>
 </form>
 <table>
@@ -59,8 +64,8 @@ tr:nth-child(odd) { background-color: #ffffff; }
     </tr>
 </thead>
 <tbody>
-{% for tid, desc, priority, due, done, status in tasks %}
-    <tr>
+{% for tid, desc, priority, due, done, status, comment, color in tasks %}
+    <tr style="background-color: {{color if color else ''}};">
         <td>{{desc}}</td>
         <td>{{priority}}</td>
         <td>{{due if due else ''}}</td>
@@ -77,6 +82,7 @@ tr:nth-child(odd) { background-color: #ffffff; }
             <form method="post" action="/delete/{{tid}}" style="display:inline;">
                 <button type="submit">Delete</button>
             </form>
+            <button type="button" onclick="openComment({{tid}}, {{comment|tojson}}, {{color|tojson}})">Comment</button>
         </td>
     </tr>
 {% endfor %}
@@ -90,6 +96,36 @@ tr:nth-child(odd) { background-color: #ffffff; }
   <a href="{{ url_for('index', page=page+1, sort=sort, q=q, status=status_filter) }}">Next</a>
 {% endif %}
 </div>
+<div id="commentBox">
+  <textarea id="commentText" rows="4" cols="40"></textarea><br>
+  <input type="color" id="commentColor" value="#ffffff"><br>
+  <button type="button" onclick="saveComment()">Save</button>
+  <button type="button" onclick="closeComment()">Close</button>
+</div>
+<script>
+function openComment(id, text, color){
+  var box=document.getElementById('commentBox');
+  box.style.display='block';
+  box.dataset.id=id;
+  document.getElementById('commentText').value=text||'';
+  document.getElementById('commentColor').value=color||'#ffffff';
+}
+function closeComment(){
+  document.getElementById('commentBox').style.display='none';
+}
+document.addEventListener('click',function(e){
+  var box=document.getElementById('commentBox');
+  if(box.style.display==='block' && !box.contains(e.target) && e.target.tagName!=='BUTTON'){
+    box.style.display='none';
+  }
+});
+function saveComment(){
+  var id=document.getElementById('commentBox').dataset.id;
+  var text=document.getElementById('commentText').value;
+  var color=document.getElementById('commentColor').value;
+  fetch('/comment/'+id,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'comment='+encodeURIComponent(text)+'&color='+encodeURIComponent(color)}).then(()=>{window.location.reload();});
+}
+</script>
 """
 
 @app.route("/")
@@ -115,6 +151,7 @@ def index():
         limit=limit,
         offset=offset,
         with_status=True,
+        with_meta=True,
     )
     total = tracker.count_tasks(show_all=True, search=q or None, status=status_filter)
     has_next = offset + limit < total
@@ -135,7 +172,9 @@ def add():
     priority = int(request.form.get("priority", 1))
     due_date = request.form.get("due_date") or None
     status = request.form.get("status", "not started")
-    tracker.add_task(description, priority, due_date, status)
+    comment = request.form.get("comment", "")
+    color = request.form.get("color", "")
+    tracker.add_task(description, priority, due_date, status, comment, color)
     return redirect(url_for("index"))
 
 @app.route("/done/<int:task_id>", methods=["POST"])
@@ -148,6 +187,13 @@ def delete(task_id: int):
     tracker.delete_task(task_id)
     return redirect(url_for("index"))
 
+@app.route("/comment/<int:task_id>", methods=["POST"])
+def comment(task_id: int):
+    comment = request.form.get("comment", "")
+    color = request.form.get("color", "")
+    tracker.update_task(task_id, comment=comment, color=color)
+    return ("", 204)
+
 @app.route("/edit/<int:task_id>", methods=["GET", "POST"])
 def edit(task_id: int):
     if request.method == "POST":
@@ -155,16 +201,20 @@ def edit(task_id: int):
         priority = request.form.get("priority")
         due_date = request.form.get("due_date") or None
         status = request.form.get("status")
+        comment = request.form.get("comment")
+        color = request.form.get("color")
         tracker.update_task(
             task_id,
             description=description,
             priority=int(priority) if priority else None,
             due_date=due_date,
             status=status,
+            comment=comment,
+            color=color,
         )
         return redirect(url_for("index"))
     task = tracker.conn.execute(
-        "SELECT description, priority, due_date, status FROM tasks WHERE id=?",
+        "SELECT description, priority, due_date, status, comment, color FROM tasks WHERE id=?",
         (task_id,),
     ).fetchone()
     edit_template = """
@@ -181,6 +231,8 @@ def edit(task_id: int):
             {% endfor %}
             </select>
         </label>
+        <label>Comment:<br><textarea name=comment rows=4 cols=40>{{t[4] or ''}}</textarea></label>
+        <label>Color:<input type=color name=color value=\"{{t[5] if t[5] else '#ffffff'}}\"></label>
         <button type=submit>Save</button>
     </form>
     <a href=\"/\">Back</a>


### PR DESCRIPTION
## Summary
- expand database schema for comment and color metadata
- support editing and adding comment and color for tasks
- show color coded rows and a modal for comments in web interface
- add endpoint to update comment and color

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843abb509448323856a478e9495ec2c